### PR TITLE
Edit, backup, and commit machine code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(
   widgets/TagItemDelegate.cc
   widgets/ToggleBox.h
   widgets/ToggleBox.cc
+  widgets/LineEdit.h
+  widgets/LineEdit.cc
 
   formats/Format.h
   formats/Format.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(
   widgets/TagItemDelegate.cc
   widgets/ToggleBox.h
   widgets/ToggleBox.cc
+  widgets/DisassemblyEditor.h
+  widgets/DisassemblyEditor.cc
   widgets/LineEdit.h
   widgets/LineEdit.cc
   widgets/TreeWidget.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(
   widgets/ToggleBox.cc
   widgets/LineEdit.h
   widgets/LineEdit.cc
+  widgets/TreeWidget.h
+  widgets/TreeWidget.cc
 
   formats/Format.h
   formats/Format.cc

--- a/src/Context.h
+++ b/src/Context.h
@@ -24,6 +24,12 @@ public:
   Disassembler::Syntax disassemblerSyntax() const;
   void setDisassemblerSyntax(Disassembler::Syntax syntax);
 
+  bool backupEnabled() const;
+  void setBackupEnabled(bool enabled);
+
+  int backupAmount() const;
+  void setBackupAmount(int amount);
+
   void loadSettings();
   void saveSettings();
 
@@ -48,6 +54,9 @@ private:
 
   bool showMachineCode_;
   Disassembler::Syntax disassemblerSyntax_;
+
+  bool backupEnabled_;
+  int backupAmount_;
 
   std::unique_ptr<Project> project_;
 };

--- a/src/Section.cc
+++ b/src/Section.cc
@@ -69,6 +69,11 @@ QString Section::toString() const
   return QString("%1 (%2)").arg(name()).arg(typeName(type()));
 }
 
+bool Section::hasAddress(quint64 addr) const
+{
+  return addr >= address() && addr < address() + size();
+}
+
 const QByteArray &Section::data() const
 {
   return data_;

--- a/src/Section.h
+++ b/src/Section.h
@@ -37,6 +37,8 @@ public:
 
   QString toString() const;
 
+  bool hasAddress(quint64 address) const;
+
   const QByteArray &data() const;
   void setData(const QByteArray &data);
 

--- a/src/widgets/BinaryWidget.cc
+++ b/src/widgets/BinaryWidget.cc
@@ -185,8 +185,14 @@ void BinaryWidget::onCustomContextMenuRequested(const QPoint &pos)
     for (auto *section : object->sections()) {
       if (section->type() == Section::Type::TEXT && section->hasAddress(userData->address)) {
         menu.addAction(tr("Edit %1").arg(section->toString()), this, [this, section] {
+          const auto priorModRegions = section->modifiedRegions();
           DisassemblyEditor editor(section, object, this);
           editor.exec();
+
+          // Only emit modified if new changes were made.
+          if (section->isModified() && section->modifiedRegions() != priorModRegions) {
+            emit modified();
+          }
         });
       }
     }

--- a/src/widgets/BinaryWidget.cc
+++ b/src/widgets/BinaryWidget.cc
@@ -412,9 +412,21 @@ void BinaryWidget::setup()
   QElapsedTimer elapsedTimer;
   elapsedTimer.start();
 
+  // Make sure we start from a clean slate.
+  mainView->clear();
+
+  symbolList->clear();
   symbolList->setEnabled(false);
+
+  stringList->clear();
   stringList->setEnabled(false);
+
+  tagList->clear();
   tagList->setEnabled(false);
+
+  offsetBlock.clear();
+  sectionBlock.clear();
+  codeBlocks.clear();
 
   QProgressDialog setupDiag(this);
   setupDiag.setLabelText(tr("Setting up for binary data.."));

--- a/src/widgets/BinaryWidget.cc
+++ b/src/widgets/BinaryWidget.cc
@@ -191,6 +191,7 @@ void BinaryWidget::onCustomContextMenuRequested(const QPoint &pos)
 
           // Only emit modified if new changes were made.
           if (section->isModified() && section->modifiedRegions() != priorModRegions) {
+            setup(); // Reload UI.
             emit modified();
           }
         });

--- a/src/widgets/BinaryWidget.cc
+++ b/src/widgets/BinaryWidget.cc
@@ -410,7 +410,7 @@ void BinaryWidget::setup()
   // Create temporary procedure name lookup map.
   QHash<quint64, QString> procNameMap;
   for (const auto &symbol : symbols) {
-    if (symbol.value() > 0 && !symbol.string().isEmpty()) {
+    if (!symbol.string().isEmpty()) {
       procNameMap[symbol.value()] = Util::demangle(symbol.string());
     }
   }
@@ -577,7 +577,7 @@ void BinaryWidget::setup()
   // Fill side bar with function names of the symbol tables.
   QSet<quint64> seenSymbols;
   for (const auto &symbol : symbols) {
-    if (symbol.value() == 0 || seenSymbols.contains(symbol.value())) {
+    if (seenSymbols.contains(symbol.value())) {
       continue;
     }
 

--- a/src/widgets/BinaryWidget.h
+++ b/src/widgets/BinaryWidget.h
@@ -19,10 +19,8 @@ class BinaryWidget : public QWidget {
 public:
   BinaryWidget(BinaryObject *object);
 
-  // void commit();
-
 signals:
-  // void modified();
+  void modified();
 
 protected:
   void showEvent(QShowEvent *event);

--- a/src/widgets/DisassemblyEditor.cc
+++ b/src/widgets/DisassemblyEditor.cc
@@ -134,6 +134,16 @@ void DisassemblyEditor::showUpdateButton()
   updateButton->show();
 }
 
+void DisassemblyEditor::done(int result)
+{
+  // Update disassembly if changed before closing dialog.
+  if (section->isModified()) {
+    updateDisassembly();
+  }
+
+  QDialog::done(result);
+}
+
 void DisassemblyEditor::showEvent(QShowEvent *event)
 {
   QDialog::showEvent(event);
@@ -165,8 +175,6 @@ void DisassemblyEditor::updateDisassembly()
 
   section->setDisassembly(std::move(result));
   qDebug() << ">" << elapsedTimer.restart() << "ms";
-
-  setup();
 }
 
 void DisassemblyEditor::createLayout()
@@ -175,7 +183,10 @@ void DisassemblyEditor::createLayout()
 
   updateButton = new QPushButton(tr("Update disassembly"));
   updateButton->hide();
-  connect(updateButton, &QPushButton::clicked, this, &DisassemblyEditor::updateDisassembly);
+  connect(updateButton, &QPushButton::clicked, this, [this] {
+    updateDisassembly();
+    setup();
+  });
 
   auto *topLayout = new QHBoxLayout;
   topLayout->setContentsMargins(5, 5, 5, 5);

--- a/src/widgets/DisassemblyEditor.cc
+++ b/src/widgets/DisassemblyEditor.cc
@@ -125,6 +125,7 @@ DisassemblyEditor::DisassemblyEditor(Section *section, BinaryObject *object, QWi
   Q_ASSERT(section->disassembly());
   Q_ASSERT(object);
 
+  setWindowTitle(tr("Disassembly Editor: %1").arg(section->toString()));
   createLayout();
 }
 

--- a/src/widgets/DisassemblyEditor.cc
+++ b/src/widgets/DisassemblyEditor.cc
@@ -254,42 +254,49 @@ void DisassemblyEditor::setup()
     treeWidget->addTopLevelItem(item);
   }
 
+  qDebug() << ">" << elapsedTimer.restart() << "ms";
+
   // Mark items as modified if a region states it.
   const auto &modRegs = section->modifiedRegions();
-  int rows = treeWidget->topLevelItemCount();
-  quint64 offset = section->address();
-  quint64 addr = 0;
-  for (int row = 0; row < rows; row++) {
-    auto *item = treeWidget->topLevelItem(row);
+  if (!modRegs.isEmpty()) {
+    qDebug() << "Marking modified regions in UI..";
 
-    // Skip procedure starts.
-    if (item->text(0).isEmpty()) {
-      continue;
-    }
+    int rows = treeWidget->topLevelItemCount();
+    quint64 offset = section->address();
+    quint64 addr = 0;
+    for (int row = 0; row < rows; row++) {
+      auto *item = treeWidget->topLevelItem(row);
 
-    addr = item->text(0).toULongLong(nullptr, 16) - offset;
-    int size = item->text(1).split(" ", QString::SkipEmptyParts).size();
-    for (const auto &reg : modRegs) {
-      if (reg.first >= addr && reg.first < addr + size) {
-        setTreeItemMarked(item, 1);
-        int excess = (reg.first + reg.second) - (addr + size);
-        if (excess == 0) continue;
+      // Skip procedure starts.
+      if (item->text(0).isEmpty()) {
+        continue;
+      }
 
-        for (int row2 = row + 1; row2 < rows; row2++) {
-          auto *item2 = treeWidget->topLevelItem(row2);
-          if (item2) {
-            int size2 = item2->text(1).split(" ", QString::SkipEmptyParts).size();
-            setTreeItemMarked(item2, 1);
-            excess -= size2;
-            if (excess <= 0) break;
+      addr = item->text(0).toULongLong(nullptr, 16) - offset;
+      int size = item->text(1).split(" ", QString::SkipEmptyParts).size();
+      for (const auto &reg : modRegs) {
+        if (reg.first >= addr && reg.first < addr + size) {
+          setTreeItemMarked(item, 1);
+          int excess = (reg.first + reg.second) - (addr + size);
+          if (excess == 0) continue;
+
+          for (int row2 = row + 1; row2 < rows; row2++) {
+            auto *item2 = treeWidget->topLevelItem(row2);
+            if (item2) {
+              int size2 = item2->text(1).split(" ", QString::SkipEmptyParts).size();
+              setTreeItemMarked(item2, 1);
+              excess -= size2;
+              if (excess <= 0) break;
+            }
+            else
+              break;
           }
-          else
-            break;
         }
       }
     }
+
+    qDebug() << ">" << elapsedTimer.restart() << "ms";
   }
 
-  qDebug() << ">" << elapsedTimer.restart() << "ms";
   treeWidget->setFocus();
 }

--- a/src/widgets/DisassemblyEditor.cc
+++ b/src/widgets/DisassemblyEditor.cc
@@ -202,6 +202,13 @@ void DisassemblyEditor::createLayout()
 
 void DisassemblyEditor::setup()
 {
+  createEntries();
+  markModifiedRegions();
+  treeWidget->setFocus();
+}
+
+void DisassemblyEditor::createEntries()
+{
   QElapsedTimer elapsedTimer;
   elapsedTimer.start();
 
@@ -255,48 +262,51 @@ void DisassemblyEditor::setup()
   }
 
   qDebug() << ">" << elapsedTimer.restart() << "ms";
+}
 
-  // Mark items as modified if a region states it.
+void DisassemblyEditor::markModifiedRegions()
+{
   const auto &modRegs = section->modifiedRegions();
-  if (!modRegs.isEmpty()) {
-    qDebug() << "Marking modified regions in UI..";
+  if (modRegs.isEmpty()) return;
 
-    int rows = treeWidget->topLevelItemCount();
-    quint64 offset = section->address();
-    quint64 addr = 0;
-    for (int row = 0; row < rows; row++) {
-      auto *item = treeWidget->topLevelItem(row);
+  QElapsedTimer elapsedTimer;
+  elapsedTimer.start();
 
-      // Skip procedure starts.
-      if (item->text(0).isEmpty()) {
-        continue;
-      }
+  qDebug() << "Marking modified regions in UI..";
 
-      addr = item->text(0).toULongLong(nullptr, 16) - offset;
-      int size = item->text(1).split(" ", QString::SkipEmptyParts).size();
-      for (const auto &reg : modRegs) {
-        if (reg.first >= addr && reg.first < addr + size) {
-          setTreeItemMarked(item, 1);
-          int excess = (reg.first + reg.second) - (addr + size);
-          if (excess == 0) continue;
+  int rows = treeWidget->topLevelItemCount();
+  quint64 offset = section->address();
+  quint64 addr = 0;
+  for (int row = 0; row < rows; row++) {
+    auto *item = treeWidget->topLevelItem(row);
 
-          for (int row2 = row + 1; row2 < rows; row2++) {
-            auto *item2 = treeWidget->topLevelItem(row2);
-            if (item2) {
-              int size2 = item2->text(1).split(" ", QString::SkipEmptyParts).size();
-              setTreeItemMarked(item2, 1);
-              excess -= size2;
-              if (excess <= 0) break;
-            }
-            else
-              break;
+    // Skip procedure starts.
+    if (item->text(0).isEmpty()) {
+      continue;
+    }
+
+    addr = item->text(0).toULongLong(nullptr, 16) - offset;
+    int size = item->text(1).split(" ", QString::SkipEmptyParts).size();
+    for (const auto &reg : modRegs) {
+      if (reg.first >= addr && reg.first < addr + size) {
+        setTreeItemMarked(item, 1);
+        int excess = (reg.first + reg.second) - (addr + size);
+        if (excess == 0) continue;
+
+        for (int row2 = row + 1; row2 < rows; row2++) {
+          auto *item2 = treeWidget->topLevelItem(row2);
+          if (item2) {
+            int size2 = item2->text(1).split(" ", QString::SkipEmptyParts).size();
+            setTreeItemMarked(item2, 1);
+            excess -= size2;
+            if (excess <= 0) break;
           }
+          else
+            break;
         }
       }
     }
-
-    qDebug() << ">" << elapsedTimer.restart() << "ms";
   }
 
-  treeWidget->setFocus();
+  qDebug() << ">" << elapsedTimer.restart() << "ms";
 }

--- a/src/widgets/DisassemblyEditor.cc
+++ b/src/widgets/DisassemblyEditor.cc
@@ -1,0 +1,289 @@
+#include "widgets/DisassemblyEditor.h"
+#include "BinaryObject.h"
+#include "Context.h"
+#include "Section.h"
+#include "Util.h"
+#include "widgets/TreeWidget.h"
+
+#include <memory>
+
+#include <QDebug>
+#include <QElapsedTimer>
+#include <QHBoxLayout>
+#include <QHash>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QStyledItemDelegate>
+#include <QVBoxLayout>
+
+namespace {
+
+void setTreeItemMarked(QTreeWidgetItem *item, int column)
+{
+  auto font = item->font(column);
+  font.setBold(true);
+  item->setFont(column, font);
+  item->setForeground(column, Qt::red);
+}
+
+class ItemDelegate : public QStyledItemDelegate {
+public:
+  ItemDelegate(DisassemblyEditor *editor, QTreeWidget *tree, BinaryObject *object, Section *section)
+    : editor(editor), tree(tree), object(object), section(section)
+  {
+  }
+
+  QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                        const QModelIndex &index) const
+  {
+    const auto col = index.column();
+    if (col != 1) {
+      return nullptr;
+    }
+
+    const auto text = index.data().toString().trimmed();
+    if (text.isEmpty()) {
+      return nullptr;
+    }
+
+    QString mask;
+    const auto blocks = text.split(" ").size();
+    for (int i = 0; i < blocks; i++) {
+      mask += "HH ";
+    }
+    if (mask.endsWith(" ")) {
+      mask.chop(1);
+    }
+
+    auto *edit = new QLineEdit(parent);
+    edit->setInputMask(mask);
+    edit->setText(text);
+    return edit;
+  }
+
+  void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+  {
+    auto *edit = qobject_cast<QLineEdit *>(editor);
+    if (!edit) return;
+
+    const auto oldStr = model->data(index).toString().trimmed();
+    auto newStr = edit->text().toUpper();
+    if (newStr == oldStr) {
+      return;
+    }
+
+    model->setData(index, newStr);
+    auto *item = tree->topLevelItem(index.row());
+    if (!item) return;
+    setTreeItemMarked(item, index.column());
+
+    // Change region.
+    const auto addr = item->text(0).toULongLong(nullptr, 16);
+    const auto pos = addr - section->address();
+    const auto data = Util::hexToData(newStr.replace(" ", ""));
+    section->setSubData(data, pos);
+
+    // Update disassembly.
+    Disassembler dis(*object, Context::get().disassemblerSyntax());
+    const auto result = dis.disassemble(data, pos);
+    if (!result) {
+      item->setText(2, tr("Could not disassemble!"));
+    }
+    else {
+      QStringList lines;
+      for (std::size_t i = 0; i < result->count(); i++) {
+        const auto *instr = result->instructions(i);
+        lines << QString("%1 %2").arg(instr->mnemonic).arg(instr->op_str);
+      }
+      item->setText(2, lines.join("   "));
+
+      if (result->count() > 1) {
+        this->editor->showUpdateButton();
+        QMessageBox::information(nullptr, "",
+                                 tr("Changes implied new instructions.") + "\n" +
+                                   tr("Disassemble again for clear representation."));
+      }
+    }
+  }
+
+private:
+  DisassemblyEditor *editor;
+  QTreeWidget *tree;
+  BinaryObject *object;
+  Section *section;
+};
+
+} // namespace
+
+DisassemblyEditor::DisassemblyEditor(Section *section, BinaryObject *object, QWidget *parent)
+  : QDialog(parent), section(section), object(object), shown(false), label(nullptr),
+    treeWidget(nullptr)
+{
+  Q_ASSERT(section);
+  Q_ASSERT(section->disassembly());
+  Q_ASSERT(object);
+
+  createLayout();
+}
+
+void DisassemblyEditor::showUpdateButton()
+{
+  updateButton->show();
+}
+
+void DisassemblyEditor::showEvent(QShowEvent *event)
+{
+  QDialog::showEvent(event);
+
+  if (!shown) {
+    shown = true;
+    setup();
+  }
+
+  Util::delayFunc([this] {
+    resize(800, 600);
+    Util::centerWidget(this);
+  });
+}
+
+void DisassemblyEditor::updateDisassembly()
+{
+  QElapsedTimer elapsedTimer;
+  elapsedTimer.start();
+
+  qDebug() << "Re-dissassembling..";
+
+  Disassembler dis(*object, Context::get().disassemblerSyntax());
+  auto result = dis.disassemble(section->data(), section->offset());
+  if (!result) {
+    QMessageBox::critical(this, "", tr("Could not disassemble machine code!"));
+    return;
+  }
+
+  section->setDisassembly(std::move(result));
+  qDebug() << ">" << elapsedTimer.restart() << "ms";
+
+  setup();
+}
+
+void DisassemblyEditor::createLayout()
+{
+  label = new QLabel;
+
+  updateButton = new QPushButton(tr("Update disassembly"));
+  updateButton->hide();
+  connect(updateButton, &QPushButton::clicked, this, &DisassemblyEditor::updateDisassembly);
+
+  auto *topLayout = new QHBoxLayout;
+  topLayout->setContentsMargins(5, 5, 5, 5);
+  topLayout->addWidget(label);
+  topLayout->addStretch();
+  topLayout->addWidget(updateButton);
+
+  treeWidget = new TreeWidget;
+  treeWidget->setHeaderLabels(QStringList{tr("Address"), tr("Data"), tr("Disassembly")});
+  treeWidget->setColumnWidth(0, object->systemBits() == 64 ? 110 : 70);
+  treeWidget->setColumnWidth(1, 200);
+  treeWidget->setColumnWidth(2, 200);
+  treeWidget->setItemDelegate(new ItemDelegate(this, treeWidget, object, section));
+  treeWidget->setMachineCodeColumns(QList<int>{1});
+  treeWidget->setCpuType(object->cpuType());
+  treeWidget->setAddressColumn(0);
+
+  auto *layout = new QVBoxLayout;
+  layout->setContentsMargins(5, 5, 5, 5);
+  layout->addLayout(topLayout);
+  layout->addWidget(treeWidget);
+
+  setLayout(layout);
+}
+
+void DisassemblyEditor::setup()
+{
+  QElapsedTimer elapsedTimer;
+  elapsedTimer.start();
+
+  qDebug() << "Generating UI for disassembly editor..";
+  treeWidget->clear();
+
+  auto *disasm = section->disassembly();
+  label->setText(tr("%1 instructions").arg(disasm->count()));
+
+  const auto &symbols = object->symbolTable().symbols();
+
+  // Create temporary procedure name lookup map.
+  QHash<quint64, QString> procNameMap;
+  for (const auto &symbol : symbols) {
+    if (!symbol.string().isEmpty()) {
+      procNameMap[symbol.value()] = Util::demangle(symbol.string());
+    }
+  }
+
+  for (std::size_t i = 0; i < disasm->count(); i++) {
+    const auto *instr = disasm->instructions(i);
+    const auto offset = instr->address;
+    const auto addr = offset + section->address();
+
+    // Check if address is the start of a procedure.
+    const auto it = procNameMap.find(addr);
+    if (it != procNameMap.end()) {
+      auto *item = new QTreeWidgetItem;
+      item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+
+      const int col = 2;
+      item->setText(col, *it);
+
+      auto font = item->font(col);
+      font.setBold(true);
+      item->setFont(col, font);
+
+      if (i > 0) {
+        treeWidget->addTopLevelItem(new QTreeWidgetItem);
+      }
+      treeWidget->addTopLevelItem(item);
+    }
+
+    auto *item = new QTreeWidgetItem;
+    item->setFlags(Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+    item->setText(0,
+                  Util::padString(QString::number(addr, 16).toUpper(), object->systemBits() / 8));
+    item->setText(1, Util::bytesToHex(instr->bytes, instr->size));
+    item->setText(2, QString("%1 %2").arg(instr->mnemonic).arg(instr->op_str));
+    treeWidget->addTopLevelItem(item);
+  }
+
+  // Mark items as modified if a region states it.
+  const auto &modRegs = section->modifiedRegions();
+  int rows = treeWidget->topLevelItemCount();
+  quint64 offset = treeWidget->topLevelItem(0)->text(0).toULongLong(nullptr, 16);
+  quint64 addr = 0;
+  for (int row = 0; row < rows; row++) {
+    auto *item = treeWidget->topLevelItem(row);
+    addr = item->text(0).toULongLong(nullptr, 16) - offset;
+    int size = item->text(1).split(" ", QString::SkipEmptyParts).size();
+    foreach (const auto &reg, modRegs) {
+      if (reg.first >= addr && reg.first < addr + size) {
+        setTreeItemMarked(item, 1);
+        int excess = (reg.first + reg.second) - (addr + size);
+        if (excess > 0) {
+          for (int row2 = row + 1; row2 < rows; row2++) {
+            auto *item2 = treeWidget->topLevelItem(row2);
+            if (item2) {
+              int size2 = item2->text(1).split(" ", QString::SkipEmptyParts).size();
+              setTreeItemMarked(item2, 1);
+              excess -= size2;
+              if (excess <= 0) break;
+            }
+            else
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  qDebug() << ">" << elapsedTimer.restart() << "ms";
+  treeWidget->setFocus();
+}

--- a/src/widgets/DisassemblyEditor.cc
+++ b/src/widgets/DisassemblyEditor.cc
@@ -87,7 +87,7 @@ public:
 
     // Update disassembly.
     Disassembler dis(*object, Context::get().disassemblerSyntax());
-    const auto result = dis.disassemble(data, pos);
+    const auto result = dis.disassemble(data, addr);
     if (!result) {
       item->setText(2, tr("Could not disassemble!"));
     }
@@ -156,7 +156,7 @@ void DisassemblyEditor::updateDisassembly()
   qDebug() << "Re-dissassembling..";
 
   Disassembler dis(*object, Context::get().disassemblerSyntax());
-  auto result = dis.disassemble(section->data(), section->offset());
+  auto result = dis.disassemble(section->data());
   if (!result) {
     QMessageBox::critical(this, "", tr("Could not disassemble machine code!"));
     return;

--- a/src/widgets/DisassemblyEditor.h
+++ b/src/widgets/DisassemblyEditor.h
@@ -25,6 +25,8 @@ private slots:
 private:
   void createLayout();
   void setup();
+  void createEntries();
+  void markModifiedRegions();
 
   Section *section;
   BinaryObject *object;

--- a/src/widgets/DisassemblyEditor.h
+++ b/src/widgets/DisassemblyEditor.h
@@ -16,8 +16,11 @@ public:
 
   void showUpdateButton();
 
+public slots:
+  void done(int result) override;
+
 protected:
-  void showEvent(QShowEvent *event);
+  void showEvent(QShowEvent *event) override;
 
 private slots:
   void updateDisassembly();

--- a/src/widgets/DisassemblyEditor.h
+++ b/src/widgets/DisassemblyEditor.h
@@ -1,0 +1,38 @@
+#ifndef SRC_WIDGETS_DISASSEMBLYEDITOR_H
+#define SRC_WIDGETS_DISASSEMBLYEDITOR_H
+
+#include <QDialog>
+
+class Section;
+class TreeWidget;
+class BinaryObject;
+
+class QLabel;
+class QPushButton;
+
+class DisassemblyEditor : public QDialog {
+public:
+  DisassemblyEditor(Section *section, BinaryObject *object, QWidget *parent = nullptr);
+
+  void showUpdateButton();
+
+protected:
+  void showEvent(QShowEvent *event);
+
+private slots:
+  void updateDisassembly();
+
+private:
+  void createLayout();
+  void setup();
+
+  Section *section;
+  BinaryObject *object;
+
+  bool shown;
+  QLabel *label;
+  QPushButton *updateButton;
+  TreeWidget *treeWidget;
+};
+
+#endif // SRC_WIDGETS_DISASSEMBLYEDITOR_H

--- a/src/widgets/LineEdit.cc
+++ b/src/widgets/LineEdit.cc
@@ -1,0 +1,26 @@
+#include <QKeyEvent>
+
+#include "LineEdit.h"
+
+LineEdit::LineEdit(QWidget *parent) : QLineEdit(parent)
+{
+}
+
+void LineEdit::focusOutEvent(QFocusEvent *event)
+{
+  QLineEdit::focusOutEvent(event);
+  emit focusLost();
+}
+
+void LineEdit::keyPressEvent(QKeyEvent *event)
+{
+  if (event->key() == Qt::Key_Up) {
+    emit keyUp();
+  }
+  else if (event->key() == Qt::Key_Down) {
+    emit keyDown();
+  }
+  else {
+    QLineEdit::keyPressEvent(event);
+  }
+}

--- a/src/widgets/LineEdit.h
+++ b/src/widgets/LineEdit.h
@@ -1,0 +1,22 @@
+#ifndef SRC_WIDGETS_LINEEDIT_H
+#define SRC_WIDGETS_LINEEDIT_H
+
+#include <QLineEdit>
+
+class LineEdit : public QLineEdit {
+  Q_OBJECT
+
+public:
+  LineEdit(QWidget *parent = nullptr);
+
+signals:
+  void focusLost();
+  void keyUp();
+  void keyDown();
+
+protected:
+  void focusOutEvent(QFocusEvent *event);
+  void keyPressEvent(QKeyEvent *event);
+};
+
+#endif // SRC_WIDGETS_LINEEDIT_H

--- a/src/widgets/MainWindow.h
+++ b/src/widgets/MainWindow.h
@@ -31,6 +31,7 @@ private slots:
   void saveProject();
   void closeProject();
   void openBinary();
+  void saveBinary();
 
   void onRecentProject();
   void onRecentBinary();
@@ -40,6 +41,7 @@ private slots:
   void onOptions();
   void onLoadSuccess(std::shared_ptr<Format> fmt);
   void onProjectModified();
+  void onBinaryModified();
 
 private:
   void setTitle(const QString &file = QString());
@@ -52,12 +54,13 @@ private:
   /** Returns false if cancelled. */
   bool checkSave();
 
-  bool modified;
+  bool modified, binaryModified;
   QString startupFile;
   QStringList recentProjects, recentBinaries;
   QByteArray geometry;
 
-  QAction *newProjectAction, *saveProjectAction, *saveAsProjectAction, *closeProjectAction;
+  QAction *newProjectAction, *saveProjectAction, *saveAsProjectAction, *closeProjectAction,
+    *saveBinaryAction;
 
   std::unique_ptr<FormatLoader> loader;
   std::shared_ptr<Format> format;

--- a/src/widgets/MainWindow.h
+++ b/src/widgets/MainWindow.h
@@ -49,6 +49,7 @@ private:
   void createLayout();
   void createMenu();
   void loadBinary(QString file);
+  void saveBackup(const QString &file);
 
   /// If modified ask to save.
   /** Returns false if cancelled. */

--- a/src/widgets/TreeWidget.cc
+++ b/src/widgets/TreeWidget.cc
@@ -1,0 +1,377 @@
+#include "widgets/TreeWidget.h"
+#include "widgets/DisassemblerDialog.h"
+#include "widgets/LineEdit.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDebug>
+#include <QInputDialog>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QMenu>
+#include <QMessageBox>
+
+TreeWidget::TreeWidget(QWidget *parent)
+  : QTreeWidget(parent), cpuType(CpuType::X86), ctxItem(nullptr), ctxCol(-1), addrColumn(-1),
+    curCol(0), curItem(0), cur(0), total(0)
+{
+  setSelectionBehavior(QAbstractItemView::SelectItems);
+  setSelectionMode(QAbstractItemView::SingleSelection);
+  setEditTriggers(QAbstractItemView::DoubleClicked);
+  setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(this, &QTreeWidget::customContextMenuRequested, this, &TreeWidget::onShowContextMenu);
+
+  // Set fixed-width font.
+  setFont(QFont("Courier"));
+
+  searchEdit = new LineEdit(this);
+  searchEdit->setVisible(false);
+  searchEdit->setFixedWidth(150);
+  searchEdit->setFixedHeight(21);
+  searchEdit->setPlaceholderText(tr("Search query"));
+  connect(searchEdit, &LineEdit::focusLost, this, &TreeWidget::onSearchLostFocus);
+  connect(searchEdit, &LineEdit::keyDown, this, &TreeWidget::nextSearchResult);
+  connect(searchEdit, &LineEdit::keyUp, this, &TreeWidget::prevSearchResult);
+  connect(searchEdit, &LineEdit::returnPressed, this, &TreeWidget::onSearchReturnPressed);
+  connect(searchEdit, &LineEdit::textEdited, this, &TreeWidget::onSearchEdited);
+
+  searchLabel = new QLabel(this);
+  searchLabel->setVisible(false);
+  searchLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  searchLabel->setFixedHeight(searchEdit->height());
+  searchLabel->setStyleSheet("QLabel { "
+                             "background-color: #EEEEEE; "
+                             "border-top: 1px solid #CCCCCC; "
+                             "}");
+}
+
+void TreeWidget::setMachineCodeColumns(const QList<int> &columns)
+{
+  if (columns.isEmpty()) {
+    machineCodeColumns.clear();
+    return;
+  }
+
+  int cols = columnCount();
+  foreach (int col, columns) {
+    if (col < cols) {
+      machineCodeColumns << col;
+    }
+  }
+  machineCodeColumns = machineCodeColumns.toSet().toList();
+  if (machineCodeColumns.size() > cols) {
+    machineCodeColumns.clear();
+  }
+}
+
+void TreeWidget::setAddressColumn(int column)
+{
+  if (column < 0 || column > columnCount() - 1) {
+    addrColumn = -1;
+    return;
+  }
+
+  addrColumn = column;
+}
+
+void TreeWidget::keyPressEvent(QKeyEvent *event)
+{
+  QTreeWidget::keyPressEvent(event);
+
+  bool ctrl{false};
+#ifdef MAC
+  ctrl = event->modifiers() | Qt::MetaModifier;
+#else
+  ctrl = event->modifiers() | Qt::ControlModifier;
+#endif
+  if (ctrl && event->key() == Qt::Key_F) {
+    doSearch();
+  }
+  else if (event->key() == Qt::Key_Escape) {
+    endSearch();
+  }
+}
+
+void TreeWidget::resizeEvent(QResizeEvent *event)
+{
+  QTreeWidget::resizeEvent(event);
+
+  if (searchEdit->isVisible()) {
+    searchEdit->move(width() - searchEdit->width() - 1, height() - searchEdit->height() - 1);
+    searchLabel->setFixedWidth(width() - searchEdit->width());
+    searchLabel->move(1, searchEdit->pos().y());
+  }
+}
+
+void TreeWidget::endSearch()
+{
+  searchEdit->hide();
+  searchLabel->hide();
+  searchEdit->clear();
+  searchLabel->clear();
+  setFocus();
+}
+
+void TreeWidget::onShowContextMenu(const QPoint &pos)
+{
+  QMenu menu;
+  menu.addAction("Search", this, SLOT(doSearch()));
+
+  if (addrColumn != -1) {
+    menu.addAction("Find address", this, SLOT(findAddress()));
+  }
+
+  ctxItem = itemAt(pos);
+  if (ctxItem) {
+    ctxCol = indexAt(pos).column();
+
+    menu.addSeparator();
+    menu.addAction("Copy field", this, SLOT(copyField()));
+    menu.addAction("Copy row", this, SLOT(copyRow()));
+
+    if (machineCodeColumns.contains(ctxCol)) {
+      menu.addSeparator();
+      menu.addAction("Disassemble", this, SLOT(disassemble()));
+    }
+  }
+
+  // Use cursor because mapToGlobal(pos) is off by the height of the
+  // tree widget header anyway.
+  menu.exec(QCursor::pos());
+
+  ctxItem = nullptr;
+  ctxCol = -1;
+}
+
+void TreeWidget::doSearch()
+{
+  searchEdit->move(width() - searchEdit->width() - 1, height() - searchEdit->height() - 1);
+  searchEdit->show();
+  searchEdit->setFocus();
+}
+
+void TreeWidget::disassemble()
+{
+  if (!ctxItem) return;
+  QString text = ctxItem->text(ctxCol);
+  quint64 offset{0};
+  if (addrColumn != -1) {
+    bool ok;
+    offset = ctxItem->text(addrColumn).toULongLong(&ok, 16);
+    if (!ok) offset = 0;
+  }
+  DisassemblerDialog diag(this, cpuType, text, offset);
+  diag.exec();
+}
+
+void TreeWidget::copyField()
+{
+  if (!ctxItem) return;
+  QString text = ctxItem->text(ctxCol);
+  QApplication::clipboard()->setText(text);
+}
+
+void TreeWidget::copyRow()
+{
+  if (!ctxItem) return;
+  QString text;
+  for (int i = 0; i < columnCount(); i++) {
+    text += ctxItem->text(i);
+    if (i < columnCount() - 1) {
+      text += "\t";
+    }
+  }
+  QApplication::clipboard()->setText(text);
+}
+
+void TreeWidget::findAddress()
+{
+  bool ok;
+  QString text = QInputDialog::getText(this, tr("Find Address"), tr("Address (hex):"),
+                                       QLineEdit::Normal, QString(), &ok);
+  if (!ok || text.isEmpty()) {
+    return;
+  }
+
+  quint64 num = text.toULongLong(&ok, 16);
+  if (!ok) {
+    QMessageBox::warning(this, "bmod", tr("Invalid address! Must be in hexadecimal."));
+    findAddress();
+    return;
+  }
+
+  int cnt = topLevelItemCount();
+  for (int i = 0; i < cnt; i++) {
+    auto *item = topLevelItem(i);
+    quint64 n = item->text(addrColumn).toULongLong(&ok, 16);
+    if (!ok) continue;
+    if (n == num) {
+      setCurrentItem(item);
+      scrollToItem(item, QAbstractItemView::PositionAtCenter);
+      return;
+    }
+
+    if (i < cnt - 1) {
+      auto *item2 = topLevelItem(i + 1);
+      quint64 n2 = item2->text(addrColumn).toULongLong(&ok, 16);
+      if (!ok) continue;
+      if (num >= n && num < n2) {
+        setCurrentItem(item);
+        scrollToItem(item, QAbstractItemView::PositionAtCenter);
+        return;
+      }
+    }
+  }
+
+  QMessageBox::information(this, "bmdo", tr("Did not find anything."));
+}
+
+void TreeWidget::resetSearch()
+{
+  searchEdit->clear();
+  searchLabel->clear();
+  searchLabel->hide();
+  searchResults.clear();
+  lastQuery.clear();
+  curCol = curItem = cur = total = 0;
+}
+
+void TreeWidget::onSearchLostFocus()
+{
+  if (searchEdit->isVisible() && searchEdit->text().isEmpty()) {
+    endSearch();
+  }
+}
+
+void TreeWidget::onSearchReturnPressed()
+{
+  QString query = searchEdit->text().trimmed();
+  if (query.isEmpty()) {
+    resetSearch();
+    return;
+  }
+
+  if (query == lastQuery) {
+    nextSearchResult();
+    return;
+  }
+
+  int cols = columnCount();
+  searchResults.clear();
+  total = 0;
+  for (int col = 0; col < cols; col++) {
+    auto res = findItems(query, Qt::MatchContains, col);
+    if (!res.isEmpty()) {
+      searchResults[col] = res;
+      total += res.size();
+    }
+  }
+
+  if (searchResults.isEmpty()) {
+    showSearchText(tr("No matches found"));
+    return;
+  }
+
+  lastQuery = query;
+  cur = 0;
+  curCol = searchResults.keys().first();
+  curItem = 0;
+  selectSearchResult(curCol, curItem);
+}
+
+void TreeWidget::selectSearchResult(int col, int item)
+{
+  if (!searchResults.contains(col)) {
+    return;
+  }
+
+  const auto &list = searchResults[col];
+  if (item < 0 || item > list.size() - 1) {
+    return;
+  }
+
+  const auto &res = list[item];
+
+  showSearchText(tr("%1 of %2 matches").arg(cur + 1).arg(total));
+
+  // Select entry and not entire row.
+  scrollToItem(res, QAbstractItemView::PositionAtCenter);
+  int row = indexOfTopLevelItem(res);
+  auto index = model()->index(row, col);
+  selectionModel()->setCurrentIndex(index, QItemSelectionModel::SelectCurrent);
+}
+
+void TreeWidget::nextSearchResult()
+{
+  const auto &list = searchResults[curCol];
+  int pos = curItem;
+  pos++;
+  if (pos > list.size() - 1) {
+    curItem = 0;
+    const auto &keys = searchResults.keys();
+    int pos2 = keys.indexOf(curCol);
+    pos2++;
+    if (pos2 > keys.size() - 1) {
+      curCol = keys[0];
+    }
+    else {
+      curCol = keys[pos2];
+    }
+  }
+  else {
+    curItem = pos;
+  }
+
+  cur++;
+  if (cur > total - 1) {
+    cur = 0;
+  }
+
+  selectSearchResult(curCol, curItem);
+}
+
+void TreeWidget::prevSearchResult()
+{
+  int pos = curItem;
+  pos--;
+  if (pos < 0) {
+    const auto &keys = searchResults.keys();
+    int pos2 = keys.indexOf(curCol);
+    pos2--;
+    if (pos2 < 0) {
+      curCol = keys.last();
+    }
+    else {
+      curCol = keys[pos2];
+    }
+    curItem = searchResults[curCol].size() - 1;
+  }
+  else {
+    curItem = pos;
+  }
+
+  cur--;
+  if (cur < 0) {
+    cur = total - 1;
+  }
+
+  selectSearchResult(curCol, curItem);
+}
+
+void TreeWidget::onSearchEdited(const QString &text)
+{
+  // If search was performed or no results were found then hide search
+  // label when editing the field.
+  if (!lastQuery.isEmpty() || searchResults.isEmpty()) {
+    searchLabel->clear();
+    searchLabel->hide();
+  }
+}
+
+void TreeWidget::showSearchText(const QString &text)
+{
+  searchLabel->setText(text + "    ");
+  searchLabel->setFixedWidth(width() - searchEdit->width());
+  searchLabel->move(1, searchEdit->pos().y());
+  searchLabel->show();
+}

--- a/src/widgets/TreeWidget.h
+++ b/src/widgets/TreeWidget.h
@@ -1,0 +1,63 @@
+#ifndef SRC_WIDGETS_TREEWIDGET_H
+#define SRC_WIDGETS_TREEWIDGET_H
+
+#include "CpuType.h"
+
+#include <QList>
+#include <QMap>
+#include <QTreeWidget>
+
+class QLabel;
+class LineEdit;
+
+class TreeWidget : public QTreeWidget {
+  Q_OBJECT
+
+public:
+  TreeWidget(QWidget *parent = nullptr);
+
+  void setCpuType(CpuType type)
+  {
+    cpuType = type;
+  }
+
+  void setMachineCodeColumns(const QList<int> &columns);
+  void setAddressColumn(int column);
+
+protected:
+  void keyPressEvent(QKeyEvent *event);
+  void resizeEvent(QResizeEvent *event);
+
+private slots:
+  void doSearch();
+  void endSearch();
+  void onSearchLostFocus();
+  void onSearchReturnPressed();
+  void nextSearchResult();
+  void prevSearchResult();
+  void onSearchEdited(const QString &text);
+  void onShowContextMenu(const QPoint &pos);
+  void disassemble();
+  void copyField();
+  void copyRow();
+  void findAddress();
+
+private:
+  void resetSearch();
+  void selectSearchResult(int col, int item);
+  void showSearchText(const QString &text);
+
+  QList<int> machineCodeColumns;
+  CpuType cpuType;
+  QTreeWidgetItem *ctxItem;
+  int ctxCol, addrColumn;
+
+  QMap<int, QList<QTreeWidgetItem *>> searchResults;
+  int curCol, curItem, cur, total;
+  QString lastQuery;
+
+  LineEdit *searchEdit;
+  QLabel *searchLabel;
+};
+
+#endif // SRC_WIDGETS_TREEWIDGET_H

--- a/tests/Section.cc
+++ b/tests/Section.cc
@@ -113,3 +113,13 @@ TEST(Section, setSubData)
     EXPECT_EQ(pair.second, 1);
   }
 }
+
+TEST(Section, hasAddress)
+{
+  Section s(Section::Type::TEXT, "test", 1, 10, 10);
+  EXPECT_FALSE(s.hasAddress(0));
+  EXPECT_TRUE(s.hasAddress(1));
+  EXPECT_TRUE(s.hasAddress(9));
+  EXPECT_TRUE(s.hasAddress(10));
+  EXPECT_FALSE(s.hasAddress(11));
+}


### PR DESCRIPTION
Fixes #14 

Changes proposed in this pull request:
- Right-clicking inside a program section (`Section::Type::TEXT`) will show "Edit Program (Text)" action that will open an instance of `DisassemblerEditor` (blocking)
- In the editor, double-clicking on the machine code section entries will make them editable inline. Pressing enter will save changes to the section and re-disassemble that single instruction line. If the modifications yields more than one instruction a dialog is shown, and the "Update disassembly" button is made available inside the editor
- Clicking the "Update disassembly" button will re-dissassemble the whole section and update the editor UI
- Upon closing the editor with changes made, it will update the `BinaryWidget` UI elements to be sure it reflects any changes in the machine code, and the title will show "(BINARY CHANGES PENDING)" until the modifications are committed to the binary file
- Pressing <kbd>ALT</kbd>+<kbd>CMD</kbd>+<kbd>s</kbd> will save the modifications to the right places in the binary file. The menu item is only enabled if any changes can be saved to the file
- Extended `Context` with binary enabled/amount values, including JSON load/save
- Extended `OptionDialog` to visually expose the binary enabled/amount values
- When saving modifications to a binary file, and backups are enabled, it will first copy the binary file to ".bakX" beside the original file with X being a growing number (0001, 0002, ..). And it will only keep as many as defined in the options dialog/context. It will remove the oldest backup when it saves the copy that exceeds the backup amount