### PR TITLE
Ignore clangd background index cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build*/
 /compile_commands.json
 /.clangd/
+/.cache/


### PR DESCRIPTION
Add `/.cache/` directory to `.gitignore`.

Clangd background indexing writes index files to this cache directory (full path: `.cache/clangd/index/`). 
